### PR TITLE
Add "Mac OS X" deviceClass condition

### DIFF
--- a/imessage/direct/albert/activationinfo.go
+++ b/imessage/direct/albert/activationinfo.go
@@ -71,7 +71,7 @@ func NewActivationInfo(privateKey *rsa.PrivateKey, versions ids.Versions) (*Acti
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csr})
 
 	deviceClass := versions.SoftwareName
-	if deviceClass == "macOS" {
+	if deviceClass == "macOS" || deviceClass == "Mac OS X" {
 		deviceClass = "MacOS"
 	}
 	udid := versions.UniqueDeviceID


### PR DESCRIPTION
- this properly addresses the issue first addressed in https://github.com/beeper/mac-registration-provider/pull/11 when using macOS devices prior to Big Sur

As is, Beeper Mini will crash if trying to register with `mac-registration-provider` when running macOS versions before v11.x as the sw_ver output provides `Mac OS X` and not `macOS`. It fails during the "generate albert push certificate" step. 

It appears that macOS versions prior to macOS 11 still report the deviceClass as `MacOS`. For reference, an ActivationInfoXML from OS X 10.7.3 on https://kb.imfreedom.org/protocols/imessage/
```
...

    <key>DeviceClass</key>
    <string>MacOS</string>
    <key>ProductType</key>
    <string>iMac10,1</string>
    <key>ProductVersion</key>
    <string>10.7.3</string>
    <key>SerialNumber</key>
    <string>XXXXX</string>
    <key>UniqueDeviceID</key>
    <string>(hexadecimal string</string>
</dict>
</plist>
```

I had tried ~30 various combinations of `Mac OS X` as the deviceClass value with the albert.py from the pypush repo with no success before finally poking around the internet to find some sort of reference of a deviceClass value pre-macOS11 and came across the XML above.