### PR TITLE
imessage/direct/ids: fix dropped error

### DIFF
--- a/imessage/direct/ids/mmcs_download.go
+++ b/imessage/direct/ids/mmcs_download.go
@@ -683,6 +683,9 @@ func (md *MMCSDownloader) Decrypt(ctx context.Context, prog *DownloadProgress, f
 		hasher.Write(data)
 		ctr.XORKeyStream(data, data)
 		_, err = file.WriteAt(data, offset)
+		if err != nil {
+			return fmt.Errorf("failed to write file: %w", err)
+		}
 		offset += int64(n)
 
 		prog.DecryptedBytes += n


### PR DESCRIPTION
This picks up a dropped `err` variable in `imessage/direct/ids`.